### PR TITLE
Refactor code and fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .DS_Store
+prefs.preset
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,13 @@
-1. Add TxalaRecGui.sc to class library (it requires the TxalaScore class to run)
-2. Create a folder and put it's path in the ~storage_path variable at the top of txalaRecorder.sc
-(this is the only thing that needs changing there)
-3. Duplicate rec_info.scd to the ~storage_path folder and make sure the channels are correct
-4. Evaluate TxalaRecorder.sc file
+## Usage
+1. Add `TxalaRecGui.sc` and `TxalaRecScore.sc` to class library
+2. Create a folder to store session information (the path to the folder will be set in `storage_path`)
+3. Duplicate `rec_info.scd` to the `storage_path` folder and make sure the channels are correct (note that the system will not run if there is not a `rec_info.scd` file in the `storage_path` folder)
+4. Evaluate the `txalaRecorder.sc` file
+- Two windows should open, a settings dialog and the TxalaScore GUI – if only the settings dialog opens then the `stoarge_path` probably hasn't been set
 5. Press Record to record audio and data
-6. rec_info.csv is created, as are data csv and aiff recordings
-7. Remember to fill out TxalaRecInfo.rtf and place it in the ~storage_path folder
+- A file named `rec_info.csv` is created that contains relevant information about the, as are data csv and aiff recordings
+6. Duplicate and fill out the `TxalaRecInfo.rtf` and place it in the `storage_path` folder
+
+## Known bugs:
+- Pitch detection is not very reliable
+- Amount of planks does not scale – level and pitch are calculated for three planks

--- a/README.md
+++ b/README.md
@@ -9,5 +9,6 @@
 6. Duplicate and fill out the `TxalaRecInfo.rtf` and place it in the `storage_path` folder
 
 ## Known bugs:
+- Control settings are only written at start – if they are changed during recording that is not represented in `rec_info.csv`
 - Pitch detection is not very reliable
 - Amount of planks does not scale – level and pitch are calculated for three planks

--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
 ## Usage
 1. Add `TxalaRecGui.sc` and `TxalaRecScore.sc` to class library
 2. Create a folder to store session information (the path to the folder will be set in `storage_path`)
-3. Duplicate `rec_info.scd` to the `storage_path` folder and make sure the channels are correct (note that the system will not run if there is not a `rec_info.scd` file in the `storage_path` folder)
+3. Duplicate `rec_info.scd` to the folder created in step 2. and make sure the channels are correct (note that the system will not run if a `rec_info.scd` file does not exist in the `storage_path` folder)
 4. Evaluate the `txalaRecorder.sc` file
-- Two windows should open, a settings dialog and the TxalaScore GUI – if only the settings dialog opens then the `stoarge_path` probably hasn't been set
-5. Press Record to record audio and data
-- A file named `rec_info.csv` is created that contains relevant information about the, as are data csv and aiff recordings
+- Two windows should open, a settings dialog and the *TxalaRecScore GUI* (if only the settings dialog opens then the `stoarge_path` probably hasn't been set)
+- A file named `rec_info.csv` is then created, which contains relevant information about the channels and controls
+5. Press Record to record audio and CSV data
+- Two files are created: a `csv` file containing data, and a `aiff` file containing the audio recording from all designated channels
 6. Duplicate and fill out the `TxalaRecInfo.rtf` and place it in the `storage_path` folder
 
 ## Known bugs:

--- a/session_tpl/rec_info.scd
+++ b/session_tpl/rec_info.scd
@@ -27,13 +27,6 @@
 	\ch9 -> "",
 ];
 
-// threshold=0.15, relaxtime=0.05, blocksize=1024, gain=0
-// settings for each baton channel
-~onsetSettings = Dictionary[
-	\chA -> [\gain, 5],
-	\ch4 -> [],
-];
-
 // Name of soundcard, if not needed leave empty string
 ~inputDevice = "16A";
 // The amount of channels on soundcard

--- a/txalaRecorder.scd
+++ b/txalaRecorder.scd
@@ -1,40 +1,49 @@
 (
-// 0. Settings
-// Where the files will be stored and the rec_info file is located ->
-// "/path/to/current/session/"
-// thisProcess.nowExecutingPath.dirname
-//~storage_path = "/Users/karljohann/Downloads/txalaparta_recordings/session2/";
-
-var data=Dictionary.new;
+// SETTINGS DIALOGUES =>
+var data = Dictionary.new;
 var thispath = thisProcess.nowExecutingPath.dirname;
-
-
-//~storage_path = "/media/r2d2/data/txala_irss_data/";
-~storage_path = "/home/r2d2/Mahaigaina/delete/";
-
-try { ~synths.collect(_.free) }; // free synths in case they are still around
-~synths = List.new;
+var persistControls;
+~storage_path = "";
+~wait_for_path = CondVar();
 
 // calibration window with auto load/save prefs
 ~controls = Dictionary.new;
 w = Window(\Session_settings, 300@100).front;
 w.view.decorator = FlowLayout(w.view.bounds);
-w.view.decorator.gap=2@2;
+w.view.decorator.gap = 2@2;
+
+persistControls = { |storage_path, controls|
+	data = Dictionary.new;
+	data.put(\storage_path, storage_path);
+	data.put(\threshold, controls[\threshold].value);
+	data.put(\relaxtime, controls[\relaxtime].value);
+	data.put(\gain, controls[\gain].value);
+	data.writeArchive(thispath ++ "/" ++ "prefs.preset");
+};
 
 ~controls[\storage_path] = Button(w, 290@20)
 .states_([
 	["storage_path", Color.white, Color.black]
 ])
 .action_({ arg butt;
-	FileDialog({|path|
-		path[0].postln;
+	FileDialog({ |path|
+		var old_path = ~storage_path;
 		~storage_path = path[0];
-		data = Dictionary.new;
-		data.put(\storage_path, ~storage_path);
-		data.put(\threshold, ~controls[\threshold].value);
-		data.put(\relaxtime, ~controls[\relaxtime].value);
-		data.writeArchive(thispath ++ "/" ++ "prefs.preset");
-	}, fileMode:2)
+		persistControls.(~storage_path, ~controls);
+		if (File.exists(~storage_path +/+ "rec_info.scd"), { // continue if file exists (else things will break)
+			~wait_for_path.signalOne; // let the process know that the storage path has been set
+			// FIXME: We should run main every time path is changed?
+			if ((old_path != ~storage_path), { // Only run if path changed
+				~main.(~storage_path);
+			});
+		}, {
+			"rec_info.scd does not exists in selected directory".postln;
+		});
+	},
+	fileMode: 2,
+	// path: if (~storage_path.notEmpty, ~storage_path, "") // Default? Just use storage_path, no ifs
+	// path: ~storage_path
+	)
 });
 w.view.decorator.nextLine;
 ~controls[\threshold] = EZSlider( w,         // parent
@@ -42,12 +51,8 @@ w.view.decorator.nextLine;
 	"threshold",  // label
 	ControlSpec(0, 1, \lin, 0.01, 0.06),     // controlSpec
 	{ arg ez;
-		~synths.do{|syn| syn.set(\threshold, ez.value)};
-		data = Dictionary.new;
-		data.put(\storage_path, ~storage_path);
-		data.put(\threshold, ~controls[\threshold].value);
-		data.put(\relaxtime, ~controls[\relaxtime].value);
-		data.writeArchive(thispath ++ "/" ++ "prefs.preset");
+		~synths.do{ |syn| syn.set(\threshold, ez.value) };
+		persistControls.(~storage_path, ~controls);
 	},
 	initVal: 0.06,
 	labelWidth: 60;
@@ -58,125 +63,78 @@ w.view.decorator.nextLine;
 	"relax time",  // label
 	ControlSpec(0, 1, \lin, 0.01, 0.01),     // controlSpec
 	{ arg ez;
-		~synths.do{|syn| syn.set(\relaxtime, ez.value)};
-		data = Dictionary.new;
-		data.put(\storage_path, ~storage_path);
-		data.put(\threshold, ~controls[\threshold].value);
-		data.put(\relaxtime, ~controls[\relaxtime].value);
-		data.writeArchive(thispath ++ "/" ++ "prefs.preset");
+		~synths.do{ |syn| syn.set(\relaxtime, ez.value) };
+		persistControls.(~storage_path, ~controls);
 	},
 	initVal: 0.01,
+	labelWidth: 60;
+);
+w.view.decorator.nextLine;
+~controls[\gain] = EZSlider( w,         // parent
+	290@20,    // bounds
+	\gain,  // label
+	ControlSpec(0, 10, \lin, 0.01, 1),     // controlSpec
+	{ arg ez;
+		~synths.do{ |syn| syn.set(\gain, ez.value) };
+		persistControls.(~storage_path, ~controls);
+	},
+	initVal: 1,
 	labelWidth: 60;
 );
 
 
 // auto read prefs file. create a default one if not there
 data = Object.readArchive(thispath ++ "/" ++ "prefs.preset");
-if (data.isNil, { //file wasn't there. create a default one
-	data=Dictionary.new;
-	data[\storage_path]= ~storage_path;
-	data[\threshold]=0.06;
-	data[\relaxtime]=0.01;
-	data.writeArchive(thispath  ++ "/" ++ "prefs.preset");
+
+if (data.isNil, { // file wasn't there. create a default one
+	var data = Dictionary[ // set default values
+		\threshold -> 0.1,
+		\relaxtime -> 0.01,
+		\gain -> 1,
+	];
+	persistControls.(~storage_path, data);
+}, {
+	~storage_path = data[\storage_path];
 });
-//data.postln;
 
-//restore the values from the prefs
-~storage_path = data[\storage_path];
-~controls[\threshold].valueAction_( data[\threshold] );
-~controls[\relaxtime].valueAction_( data[\relaxtime] );
-
-
-
-
-// 1. Init
-// load the settings dictionary (~recInfo)
-(~storage_path +/+ "rec_info.scd").load;
-
-if ((~inputDevice.size > 0), {
-	Server.default.options.inDevice_(~inputDevice); // set to soundcard if needed
-});
-Server.default.options.numInputBusChannels_(~numInputChannels);
-s = Server.local;
-s.meter(8, 8); // opens the meter window
-if (not(s.serverRunning), { s.boot }); // start server
-
-thisProcess.platform.recordingsDir = ~storage_path; // recordings will be stored here
-
-// Write recInfo to CSV file for posterity
-~writeConfig = {
-	var filepath = ~storage_path +/+ "rec_info.csv";
-	var csvfile = File(filepath, "w");
-	var headers = "";
-	var channels = "";
-
-	// gather channel info
-	~recInfo.keysValuesDo{ |key, val|
-		headers = headers ++ key.asString ++ ",";
-		channels = channels ++ val.asString ++ ",";
-	};
-
-	headers = headers ++ "storagepath";
-	channels = channels ++ ~storage_path;
-
-	csvfile.write( headers );
-	csvfile.write( "\n" );
-	csvfile.write( channels );
-	csvfile.close;
+// restore the values from the prefs
+~synths.do{ |syn|
+	syn.set(
+		\threshold, data[\threshold],
+		\relaxtime, data[\relaxtime],
+		\gain, data[\gain],
+	);
 };
-~writeConfig.();
-
-// Returns channels for batons and planks
-~getChannels = { |type = \baton|
-	var toMatch = if (type == \baton, "p[0-9][rl]", "plk[0-9]");
-	var channels = [];
-	~recInfo.keysValuesDo{ |key, val|
-		if (toMatch.matchRegexp(val), {
-			var in = key.asString.findRegexp("ch([0-9]+)");
-			var ch = in[1][1].asInteger - 1;
-			channels = channels.add(ch);
-		});
-	};
-	channels;
-};
-
-// Returns channels to record
-~getRecChannels = {
-	var recChannels = [];
-	~recInfo.keysValuesDo{ |key, val|
-		if (val != "", {
-			var in = key.asString.findRegexp("ch([0-9]+)");
-			var ch = in[1][1].asInteger - 1;
-			recChannels = recChannels.add(ch);
-		});
-	};
-	recChannels;
+// set the sliders but dont trigger the action at this moment
+~controls.keysDo{ |key|
+	~controls[key].value_( data[key] );
 };
 
 
 
-// 2. Onset detection synth
-SynthDef(\detector, { |in=0, threshold=0.06, relaxtime=0.01, blocksize=1024, gain=0|
+
+// ONSET detection synth =>
+SynthDef(\detector, { |in=0, threshold=0.06, relaxtime=0.01, blocksize=1024, gain=1|
 	var plank_lvl, plank_idx, freq, hasFreq, baton_lvl, onsets, delayedOnsets, fft;
 	var sdel = 0.04; // [threeinputs.scd] this is a small delay to skip the first chaotic miliseconds
-	var plank_channels = ~getChannels.(\plk);
+	var plank_channels = NamedControl.kr(\plank_channels, [4, 5, 6]);
 
 	var baton = SoundIn.ar(in) * gain;
 	var planks = SoundIn.ar(plank_channels) * gain;
 	var planklevels = WAmp.kr(planks, sdel);
-
 	var freqs = Array.newClear(plank_channels.size);
 
 	# plank_lvl, plank_idx = ArrayMax.ar(planklevels); // # val, index
+	# freq, hasFreq = Pitch.kr(SoundIn.ar(in), ampThreshold:0.0001, median:7);
 
 	plank_channels.do{ |plk_ch, i|
-		freqs[i] = Pitch.kr(SoundIn.ar(plk_ch), ampThreshold:0.02, median:7); // # freq, hasFreq
+		freqs[i] = Pitch.kr(SoundIn.ar(plk_ch), ampThreshold:0.0001); // # freq, hasFreq
 	};
 
 	baton_lvl = WAmp.kr(baton, 0.1); // Window size should probably be around 50 ms? (0.05)
 
 	fft = FFT(LocalBuf(blocksize), baton, wintype:1);
-	onsets = Onsets.kr(fft, threshold, odftype:\power, relaxtime:relaxtime, mingap:4);
+	onsets = Onsets.kr(fft, threshold, odftype:\power, relaxtime: relaxtime, mingap:4);
 	delayedOnsets = DelayN.kr(onsets, maxdelaytime:sdel, delaytime:sdel); // delay onsets to get plank
 
 	SendReply.kr(delayedOnsets, '/input', [
@@ -188,26 +146,129 @@ SynthDef(\detector, { |in=0, threshold=0.06, relaxtime=0.01, blocksize=1024, gai
 		planklevels[0],
 		planklevels[1],
 		planklevels[2],
-		freqs[0][0], // FIXME: Not really working
-		freqs[1][0], // FIXME: Not really working
-		freqs[2][0], // FIXME: Not really working
+		freq,
+		freqs[0][0],
+		freqs[1][0],
+		freqs[2][0],
 	]);
 
 }).add;
 
-// 3. OSC server ->
-OSCFunc({
-	arg msg;
+
+
+
+// MAIN =>
+// Cannot be run until storage_path has been set
+~main = { arg storage_path;
+	// load the settings dictionary (~recInfo)
+	(storage_path +/+ "rec_info.scd").load; // TODO: Add rec_info configs to GUI?
+
+	if ((~inputDevice.size > 0), {
+		Server.default.options.inDevice_(~inputDevice); // set to soundcard if needed
+	});
+	Server.default.options.numInputBusChannels_(~numInputChannels);
+	s = Server.local;
+	// s.meter(8, 8); // opens the meter window      /// FIXME: gets errors
+	if (not(s.serverRunning), { s.boot }); // start server
+
+	thisProcess.platform.recordingsDir = storage_path; // recordings will be stored here
+
+
+	// Write recInfo to CSV file for posterity ->
+	~writeConfig = {
+		var filepath = storage_path +/+ "rec_info.csv";
+		var csvfile = File(filepath, "w");
+		var headers = "";
+		var channels = "";
+
+		// gather channel info
+		~recInfo.keysValuesDo{ |key, val|
+			headers = headers ++ key.asString ++ ",";
+			channels = channels ++ val.value.asString ++ ",";
+		};
+
+		// TODO: Write controls values?
+/*		~controls.keysValuesDo{ |key, val|
+			headers = headers ++ key.asString ++ ",";
+			channels = channels ++ val.value.asString ++ ",";
+		};*/
+
+		csvfile.write( headers );
+		csvfile.write( "\n" );
+		csvfile.write( channels );
+		csvfile.close;
+	}.();
+
+	// Get channels for batons and planks ->
+	~getChannels = {
+		var channels = Dictionary[\baton -> [], \plk -> []];
+		~recInfo.keysValuesDo{ |key, val|
+			var in = key.asString.findRegexp("ch([0-9]+)");
+			var ch = in[1][1].asInteger - 1;
+			if ("p[0-9][rl]".matchRegexp(val), {
+				channels[\baton] = channels[\baton].add(ch);
+			});
+			if ("plk[0-9]".matchRegexp(val), {
+				channels[\plk] = channels[\plk].add(ch);
+			});
+		};
+		channels;
+	};
+
+	// Returns channels to record ->
+	~getRecChannels = {
+		var recChannels = [];
+		~recInfo.keysValuesDo{ |key, val|
+			if (val != "", {
+				var in = key.asString.findRegexp("ch([0-9]+)");
+				var ch = in[1][1].asInteger - 1;
+				recChannels = recChannels.add(ch);
+			});
+		};
+		recChannels;
+	};
+
+
+	s.waitForBoot{
+		// get the batons to listen to from recInfo ->
+		var channels = ~getChannels.();
+		~synths!?.collect(_.free); // free synths in case they are still around
+		~synths = List.new;
+		channels[\baton].do{ |ch|
+			// create onset detection synth for each baton
+			~synths = ~synths.add( Synth(\detector, [\in, ch]).setn(\plank_channels, channels[\plk]) );
+		};
+
+		// Init GUI ->
+		if (t.isNil, {
+			t = TxalaRecGUI.new;
+			t.doTxalaScore();
+			t.updateNumPlanks(3);
+		});
+		t.setFileStoragePath(storage_path);
+		t.setRecChannels(~getRecChannels.());
+	};
+};
+
+
+// Wait until user has entered storage path ->
+fork {
+	~wait_for_path.wait({ (~storage_path.notEmpty) });
+	"Storage path has been set to: '%'\n".postf(~storage_path);
+	~main.(~storage_path);
+};
+
+
+// OSC server =>
+OSCFunc({ arg msg;
+	var args;
 
 	// calculate timedelta ->
 	var clock = msg[7].asFloat;
 	var lasttime = if ((t.lasttime == 0), clock, t.lasttime);
 	var timedelta = clock - lasttime;
-	var args, player;
 
 	t.lasttime = clock;
-
-	// msg.postln;
 
 	args = Dictionary[
 		\baton -> msg[3].asInteger,
@@ -216,52 +277,17 @@ OSCFunc({
 		\plank_lvl -> msg[6].asFloat, // salient plank level
 		\timedelta -> timedelta,
 		\clock -> clock,
-		\pitch -> msg[11],
 		\plank_lvl_1 -> msg[8].asFloat,
 		\plank_lvl_2 -> msg[9].asFloat,
 		\plank_lvl_3 -> msg[10].asFloat,
+		\pitch_baton -> msg[11].asFloat,
+		\pitch_plk1 -> msg[12].asFloat,
+		\pitch_plk2 -> msg[13].asFloat,
+		\pitch_plk3 -> msg[14].asFloat,
 	];
 
 	t.hit(SystemClock.seconds, args[\baton_lvl], args[\plank], (args[\baton] + 1), args);
 
 }, '/input');
 
-
-// 4. Main
-s.waitForBoot{
-	m = {
-		// The values that will be saved to CSV file
-		var keys = [ // TODO: This has to be the same as dict below, avoid duplication
-			\baton,
-			\plank,
-			\baton_lvl,
-			\plank_lvl,
-			\timedelta,
-			\clock,
-			\pitch,
-			\plank_lvl_1,
-			\plank_lvl_2,
-			\plank_lvl_3,
-		];
-
-		// get the batons to listen to from recInfo ->
-		var batonChannels = ~getChannels.();
-		batonChannels.do{ |ch|
-			// create onset detection synth for each baton
-			~synths.add( Synth(\detector, [\in, ch]) );
-		};
-
-		// Init GUI ->
-		t = TxalaRecGUI.new;
-		t.doTxalaScore();
-		t.updateNumPlanks(3);
-		t.setFileStoragePath(~storage_path);
-		t.setCSVKeys(keys);
-		t.setRecChannels(~getRecChannels);
-	};
-	m.();
-}
 )
-
-// Stop recording ->
-// Server.default.stopRecording; // also stops on cmd-.

--- a/txalaRecorder.scd
+++ b/txalaRecorder.scd
@@ -249,10 +249,12 @@ SynthDef(\detector, { |in=0, threshold=0.06, relaxtime=0.01, blocksize=1024, gai
 		~synths = List.new;
 		~channels[\baton].do{ |ch|
 			// create onset detection synth for each baton
-			~synths = ~synths.add(
-				Synth(\detector, [\in, ch])
-				.setn(\plank_channels, ~channels[\plk])
-			);
+			var synth = Synth(\detector, [\in, ch]);
+			synth.setn(\plank_channels, ~channels[\plk]);
+			~controls.keysValuesDo{ |key, item|
+				synth.setn(key.asSymbol, item.value.asFloat)
+			};
+			~synths = ~synths.add(synth);
 		};
 
 		// Init GUI ->

--- a/txalaRecorder.scd
+++ b/txalaRecorder.scd
@@ -1,115 +1,118 @@
 (
 // SETTINGS DIALOGUES =>
-var data = Dictionary.new;
 var thispath = thisProcess.nowExecutingPath.dirname;
-var persistControls;
 ~storage_path = "";
 ~wait_for_path = CondVar();
 
 // calibration window with auto load/save prefs
-~controls = Dictionary.new;
-w = Window(\Session_settings, 300@100).front;
-w.view.decorator = FlowLayout(w.view.bounds);
-w.view.decorator.gap = 2@2;
+{
+	var data = Dictionary.new;
+	var persistControls;
+	var labelWidth = 80;
+	var boundWidth = 360;
+	~controls = Dictionary.new;
+	w = Window(\Session_settings, (boundWidth + 10)@120).front;
+	w.view.decorator = FlowLayout(w.view.bounds);
+	w.view.decorator.gap = 2@2;
 
-persistControls = { |storage_path, controls|
-	data = Dictionary.new;
-	data.put(\storage_path, storage_path);
-	data.put(\threshold, controls[\threshold].value);
-	data.put(\relaxtime, controls[\relaxtime].value);
-	data.put(\gain, controls[\gain].value);
-	data.writeArchive(thispath ++ "/" ++ "prefs.preset");
-};
+	persistControls = { |storage_path, controls|
+		data = Dictionary.new;
+		data.put(\storage_path, storage_path);
+		data.put(\threshold, controls[\threshold].value);
+		data.put(\relaxtime, controls[\relaxtime].value);
+		data.put(\gain, controls[\gain].value);
+		data.writeArchive(thispath ++ "/" ++ "prefs.preset");
+	};
 
-~storage_path_control = Button(w, 290@20)
-.states_([
-	["storage_path", Color.white, Color.black]
-])
-.action_({ arg butt;
-	FileDialog({ |path|
-		var old_path = ~storage_path;
-		~storage_path = path[0];
-		persistControls.(~storage_path, ~controls);
-		if (File.exists(~storage_path +/+ "rec_info.scd"), { // continue if file exists (else things will break)
-			~wait_for_path.signalOne; // let the process know that the storage path has been set
-			// FIXME: We should run main every time path is changed?
-			if ((old_path != ~storage_path), { // Only run if path changed
-				~main.(~storage_path);
+	Button(w, boundWidth@20)
+	.states_([
+		["storage_path", Color.white, Color.black]
+	])
+	.action_({ arg butt;
+		FileDialog({ |path|
+			var old_path = ~storage_path;
+			~storage_path = path[0];
+			persistControls.(~storage_path, ~controls);
+			if (File.exists(~storage_path +/+ "rec_info.scd"), { // continue if file exists (else things will break)
+				~wait_for_path.signalOne; // let the process know that the storage path has been set
+				// FIXME: We should run main every time path is changed?
+				if ((old_path != ~storage_path), { // Only run if path changed
+					~main.(~storage_path);
+				});
+			}, {
+				"rec_info.scd does not exists in selected directory".postln;
 			});
-		}, {
-			"rec_info.scd does not exists in selected directory".postln;
-		});
-	},
-	fileMode: 2,
-	path: if (~storage_path.notEmpty, ~storage_path)
-	// path: ~storage_path
-	)
-});
-w.view.decorator.nextLine;
-~controls[\threshold] = EZSlider( w,         // parent
-	290@20,    // bounds
-	"threshold",  // label
-	ControlSpec(0, 1, \lin, 0.001, 0.06),     // controlSpec
-	{ arg ez;
-		~synths.do{ |syn| syn.set(\threshold, ez.value) };
-		persistControls.(~storage_path, ~controls);
-	},
-	initVal: 0.06,
-	labelWidth: 60;
-);
-~controls[\threshold].numberView.maxDecimals = 3 ;
-w.view.decorator.nextLine;
-~controls[\relaxtime] = EZSlider( w,         // parent
-	290@20,    // bounds
-	"relax time",  // label
-	ControlSpec(0, 1, \lin, 0.01, 0.01),     // controlSpec
-	{ arg ez;
-		~synths.do{ |syn| syn.set(\relaxtime, ez.value) };
-		persistControls.(~storage_path, ~controls);
-	},
-	initVal: 0.01,
-	labelWidth: 60;
-);
-w.view.decorator.nextLine;
-~controls[\gain] = EZSlider( w,         // parent
-	290@20,    // bounds
-	\gain,  // label
-	ControlSpec(0, 10, \lin, 0.01, 1),     // controlSpec
-	{ arg ez;
-		~synths.do{ |syn| syn.set(\gain, ez.value) };
-		persistControls.(~storage_path, ~controls);
-	},
-	initVal: 1,
-	labelWidth: 60;
-);
-
-// auto read prefs file. create a default one if not there
-data = Object.readArchive(thispath ++ "/" ++ "prefs.preset");
-
-if (data.isNil, { // file wasn't there. create a default one
-	var data = Dictionary[ // set default values
-		\threshold -> 0.1,
-		\relaxtime -> 0.01,
-		\gain -> 1,
-	];
-	persistControls.(~storage_path, data);
-}, {
-	~storage_path = data[\storage_path];
-});
-
-// restore the values from the prefs
-~synths.do{ |syn|
-	syn.set(
-		\threshold, data[\threshold],
-		\relaxtime, data[\relaxtime],
-		\gain, data[\gain],
+		},
+		fileMode: 2,
+		path: if (~storage_path.notEmpty, ~storage_path)
+		// path: ~storage_path
+		)
+	});
+	w.view.decorator.nextLine;
+	~controls[\threshold] = EZSlider( w,         // parent
+		boundWidth@20,    // bounds
+		"threshold",  // label
+		ControlSpec(0, 1, \lin, 0.001, 0.06),     // controlSpec
+		{ arg ez;
+			~synths.do{ |syn| syn.set(\threshold, ez.value) };
+			persistControls.(~storage_path, ~controls);
+		},
+		initVal: 0.06,
+		labelWidth: labelWidth;
 	);
-};
-// set the sliders but dont trigger the action at this moment
-~controls.keysDo{ |key|
-	~controls[key].value_( data[key] );
-};
+	~controls[\threshold].numberView.maxDecimals = 3;
+	w.view.decorator.nextLine;
+	~controls[\relaxtime] = EZSlider( w,         // parent
+		boundWidth@20,    // bounds
+		"relax time",  // label
+		ControlSpec(0, 1, \lin, 0.01, 0.01),     // controlSpec
+		{ arg ez;
+			~synths.do{ |syn| syn.set(\relaxtime, ez.value) };
+			persistControls.(~storage_path, ~controls);
+		},
+		initVal: 0.01,
+		labelWidth: labelWidth;
+	);
+	w.view.decorator.nextLine;
+	~controls[\gain] = EZSlider( w,         // parent
+		boundWidth@20,    // bounds
+		\gain,  // label
+		ControlSpec(0, 10, \lin, 0.01, 1),     // controlSpec
+		{ arg ez;
+			~synths.do{ |syn| syn.set(\gain, ez.value) };
+			persistControls.(~storage_path, ~controls);
+		},
+		initVal: 1,
+		labelWidth: labelWidth;
+	);
 
+	// auto read prefs file. create a default one if not there
+	data = Object.readArchive(thispath ++ "/" ++ "prefs.preset");
+
+	if (data.isNil, { // file wasn't there. create a default one
+		var data = Dictionary[ // set default values
+			\threshold -> 0.1,
+			\relaxtime -> 0.01,
+			\gain -> 1,
+		];
+		persistControls.(~storage_path, data);
+	}, {
+		~storage_path = data[\storage_path];
+	});
+
+	// restore the values from the prefs
+	~synths.do{ |syn|
+		syn.set(
+			\threshold, data[\threshold],
+			\relaxtime, data[\relaxtime],
+			\gain, data[\gain],
+		);
+	};
+	// set the sliders but dont trigger the action at this moment
+	~controls.keysDo{ |key|
+		~controls[key].value_( data[key] );
+	};
+}.();
 
 
 

--- a/txalaRecorder.scd
+++ b/txalaRecorder.scd
@@ -262,7 +262,7 @@ fork {
 
 // OSC server =>
 OSCFunc({ arg msg;
-	var args;
+	var args, dargs;
 
 	// calculate timedelta ->
 	var clock = msg[7].asFloat;
@@ -271,7 +271,7 @@ OSCFunc({ arg msg;
 
 	t.lasttime = clock;
 
-	args = Dictionary[
+	args = [
 		\baton -> msg[3].asInteger,
 		\plank -> msg[5].asInteger,
 		\baton_lvl -> msg[4].asFloat,
@@ -287,7 +287,12 @@ OSCFunc({ arg msg;
 		\pitch_plk3 -> msg[14].asFloat,
 	];
 
-	t.hit(SystemClock.seconds, args[\baton_lvl], args[\plank], (args[\baton] + 1), args);
+	dargs = args.asDict; //
+
+	t.hit(SystemClock.seconds, dargs[\baton_lvl], dargs[\plank], (dargs[\baton] + 1));
+	if (t.isRecording, {
+		t.writeCSV(args);
+	});
 
 }, '/input');
 

--- a/txalaRecorder.scd
+++ b/txalaRecorder.scd
@@ -35,7 +35,7 @@ var thispath = thisProcess.nowExecutingPath.dirname;
 			persistControls.(~storage_path, ~controls);
 			if (File.exists(~storage_path +/+ "rec_info.scd"), { // continue if file exists (else things will break)
 				~wait_for_path.signalOne; // let the process know that the storage path has been set
-				// FIXME: We should run main every time path is changed?
+				// re-run main every time path is changed
 				if ((old_path != ~storage_path), { // Only run if path changed
 					~main.(~storage_path);
 				});
@@ -45,7 +45,6 @@ var thispath = thisProcess.nowExecutingPath.dirname;
 		},
 		fileMode: 2,
 		path: if (~storage_path.notEmpty, ~storage_path)
-		// path: ~storage_path
 		)
 	});
 	w.view.decorator.nextLine;

--- a/txalaRecorder.scd
+++ b/txalaRecorder.scd
@@ -41,7 +41,7 @@ persistControls = { |storage_path, controls|
 		});
 	},
 	fileMode: 2,
-	// path: if (~storage_path.notEmpty, ~storage_path, "") // Default? Just use storage_path, no ifs
+	path: if (~storage_path.notEmpty, ~storage_path)
 	// path: ~storage_path
 	)
 });

--- a/txalaRecorder.scd
+++ b/txalaRecorder.scd
@@ -1,12 +1,11 @@
 (
-// SETTINGS DIALOGUES =>
-var thispath = thisProcess.nowExecutingPath.dirname;
 ~storage_path = "";
 ~wait_for_path = CondVar();
 
-// calibration window with auto load/save prefs
-{
+// SETTINGS DIALOGUES =>
+{ // calibration window with auto load/save prefs
 	var data = Dictionary.new;
+	var thispath = thisProcess.nowExecutingPath.dirname;
 	var persistControls;
 	var labelWidth = 80;
 	var boundWidth = 360;

--- a/txalaRecorder.scd
+++ b/txalaRecorder.scd
@@ -21,7 +21,7 @@ persistControls = { |storage_path, controls|
 	data.writeArchive(thispath ++ "/" ++ "prefs.preset");
 };
 
-~controls[\storage_path] = Button(w, 290@20)
+~storage_path_control = Button(w, 290@20)
 .states_([
 	["storage_path", Color.white, Color.black]
 ])
@@ -188,11 +188,11 @@ SynthDef(\detector, { |in=0, threshold=0.06, relaxtime=0.01, blocksize=1024, gai
 			channels = channels ++ val.value.asString ++ ",";
 		};
 
-		// TODO: Write controls values?
-/*		~controls.keysValuesDo{ |key, val|
+		// Write controls values
+		~controls.keysValuesDo{ |key, item|
 			headers = headers ++ key.asString ++ ",";
-			channels = channels ++ val.value.asString ++ ",";
-		};*/
+			channels = channels ++ item.value.asString ++ ",";
+		};
 
 		csvfile.write( headers );
 		csvfile.write( "\n" );

--- a/txalaRecorder.scd
+++ b/txalaRecorder.scd
@@ -201,7 +201,7 @@ SynthDef(\detector, { |in=0, threshold=0.06, relaxtime=0.01, blocksize=1024, gai
 	}.();
 
 	// Get channels for batons and planks ->
-	~getChannels = {
+	~channels = {
 		var channels = Dictionary[\baton -> [], \plk -> []];
 		~recInfo.keysValuesDo{ |key, val|
 			var in = key.asString.findRegexp("ch([0-9]+)");
@@ -214,10 +214,24 @@ SynthDef(\detector, { |in=0, threshold=0.06, relaxtime=0.01, blocksize=1024, gai
 			});
 		};
 		channels;
-	};
+	}.();
+
+	// Get channels for batons ->
+	~playerChannels = {
+		var players = Dictionary.new;
+		~recInfo.keysValuesDo{ |key, val|
+			var in = key.asString.findRegexp("ch([0-9]+)");
+			var ch = in[1][1].asInteger - 1;
+			if ("p[0-9][rl]".matchRegexp(val), {
+				var p = val.findRegexp("p([0-9])[rl]");
+				players[ch] = p[1][1].asInteger - 1;
+			});
+		};
+		players;
+	}.();
 
 	// Returns channels to record ->
-	~getRecChannels = {
+	~recChannels = {
 		var recChannels = [];
 		~recInfo.keysValuesDo{ |key, val|
 			if (val != "", {
@@ -227,17 +241,18 @@ SynthDef(\detector, { |in=0, threshold=0.06, relaxtime=0.01, blocksize=1024, gai
 			});
 		};
 		recChannels;
-	};
+	}.();
 
 
 	s.waitForBoot{
-		// get the batons to listen to from recInfo ->
-		var channels = ~getChannels.();
 		~synths!?.collect(_.free); // free synths in case they are still around
 		~synths = List.new;
-		channels[\baton].do{ |ch|
+		~channels[\baton].do{ |ch|
 			// create onset detection synth for each baton
-			~synths = ~synths.add( Synth(\detector, [\in, ch]).setn(\plank_channels, channels[\plk]) );
+			~synths = ~synths.add(
+				Synth(\detector, [\in, ch])
+				.setn(\plank_channels, ~channels[\plk])
+			);
 		};
 
 		// Init GUI ->
@@ -247,7 +262,7 @@ SynthDef(\detector, { |in=0, threshold=0.06, relaxtime=0.01, blocksize=1024, gai
 			t.updateNumPlanks(3);
 		});
 		t.setFileStoragePath(storage_path);
-		t.setRecChannels(~getRecChannels.());
+		t.setRecChannels(~recChannels);
 	};
 };
 
@@ -262,13 +277,12 @@ fork {
 
 // OSC server =>
 OSCFunc({ arg msg;
-	var args, dargs;
+	var args, args_dict, players;
 
 	// calculate timedelta ->
 	var clock = msg[7].asFloat;
 	var lasttime = if ((t.lasttime == 0), clock, t.lasttime);
 	var timedelta = clock - lasttime;
-
 	t.lasttime = clock;
 
 	args = [
@@ -287,13 +301,18 @@ OSCFunc({ arg msg;
 		\pitch_plk3 -> msg[14].asFloat,
 	];
 
-	dargs = args.asDict; //
+	args_dict = args.asDict; // to access the key-value in t.hit
+	t.hit(
+		hittime: SystemClock.seconds,
+		amp: args_dict[\baton_lvl],
+		plank: args_dict[\plank],
+		stick: (args_dict[\baton] + 1),
+		player: ~playerChannels[args_dict[\baton]],
+	);
 
-	t.hit(SystemClock.seconds, dargs[\baton_lvl], dargs[\plank], (dargs[\baton] + 1));
 	if (t.isRecording, {
 		t.writeCSV(args);
 	});
-
 }, '/input');
 
 )

--- a/txalarecscore/TxalaRecGUI.sc
+++ b/txalarecscore/TxalaRecGUI.sc
@@ -39,7 +39,7 @@ TxalaRecGUI {
 	var txalascoreevents, txalascoremarks, txalascore, timelinewin, txalascoreF, txalascoresttime, csvfile, <>recChannels;
 	var isRecording = false;
 	var storagepath = "~/"; // assuming unix-based OS
-	var filepath, csvKeys;
+	var filepath;
 	var <>lasttime = 0; // init time of last hit
 
 	*new {
@@ -73,17 +73,16 @@ TxalaRecGUI {
 		storagepath = path.asString;
 	}
 
-	setCSVKeys { arg keys;
-		csvKeys = keys;
+	setFilepath { arg timestamp;
+		filepath = storagepath +/+ "sc_txala_rec_" ++ timestamp ++ ".csv";
 	}
 
-	initCSVFile { arg timestamp;
+	initCSVFile { arg keys;
 		var csvfile;
 		var headers = "";
-		// NOTE: storagepath and csvKeys have to be set first
-		filepath = storagepath +/+ "sc_txala_rec_" ++ timestamp ++ ".csv";
+
 		csvfile = File(filepath, "w");
-		csvKeys.do{ |key|
+		keys.do{ |key|
 			headers = headers ++ key.asString ++ ",";
 		};
 		csvfile.write( headers );
@@ -91,13 +90,13 @@ TxalaRecGUI {
 	}
 
 	writeCSV { arg args;
-		// if (not(File.exists(filepath)), { // TODO: Check for race-condition
-		// this.initCSVFile(filepath);
-		// });
+		if (not(File.exists(filepath)), { // TODO: Check for race-condition
+			this.initCSVFile(args.keys);
+		});
 
 		csvfile = File(filepath, "a");
 		csvfile.write("\n"); // write new line bc append does not
-		csvKeys.do{ |key|
+		args.keys.do{ |key|
 			csvfile.write( args[key].asString ++ ",");
 		};
 		csvfile.close;
@@ -205,7 +204,7 @@ TxalaRecGUI {
 					Server.default.record(numChannels: 8);
 					isRecording = true;
 					this.changebg();
-					this.initCSVFile(Date.getDate.stamp);
+					this.setFilepath(Date.getDate.stamp);
 				}, {
 					if ((butt.value == 0), {
 						Server.default.stopRecording;

--- a/txalarecscore/TxalaRecGUI.sc
+++ b/txalarecscore/TxalaRecGUI.sc
@@ -16,8 +16,6 @@ t = TxalaRecGUI.new;
 t.doTxalaScore();
 t.updateNumPlanks(n);
 t.setFileStoragePath(~storage_path);
-t.setCSVKeys(keys);
-t.setChannelSize(~numInputChannels.asInteger);
 
 p = true;
 
@@ -106,11 +104,10 @@ TxalaRecGUI {
 	}
 
 
-	hit { arg hittime, amp, plank=nil, stick=nil;
-		var hitdata, playerFromStick, player;
+	hit { arg hittime, amp, plank=nil, stick=nil, player=nil;
+		var hitdata;
 		if (txalascore.isNil.not, {
 			hittime = hittime - txalascoresttime;
-			player = if ((stick < 2), 0, 1); // FIXME: Channels could be any, need an dict of batons
 			hitdata = ().add(\time -> hittime)
 			            .add(\amp -> amp)
 					    .add(\player -> player)

--- a/txalarecscore/TxalaRecGUI.sc
+++ b/txalarecscore/TxalaRecGUI.sc
@@ -204,7 +204,7 @@ TxalaRecGUI {
 					Server.default.record(numChannels: 8);
 					isRecording = true;
 					this.changebg();
-					this.setFilepath(Date.getDate.stamp);
+					this.setFilepath(Date.getDate.stamp); // Update the filepath so it doesnt overwrite
 				}, {
 					if ((butt.value == 0), {
 						Server.default.stopRecording;


### PR DESCRIPTION
* Refactor code to simplify it
* Make it so storage path has to be set (via GUI) before starting session
* Change flow so it is possible to change storage_path without re-evaluating code
* Update README to reflect changes in code
* Minor bugfixes

**HOW TO TEST:**
1. Delete prefs.preset (if it exists)
2. Evaluate txalaRecorder.scd
3. See that only the settings dialog opens
4. Set storage path
5. See that TxalaScoreGUI opens
6. Press record and see that files are saved to storage_path folder
7. Change storage_path and repeat step 6.
8. See that files are saved in new path
9. Close window and re-evaluate path
10. Repeat step 6.

Also check that all channels are correctly stored
